### PR TITLE
Filter state of the Data Storage Screen now remains the same after an atKey is deleted, less the deleted key.

### DIFF
--- a/lib/controllers/at_data_controller.dart
+++ b/lib/controllers/at_data_controller.dart
@@ -35,6 +35,7 @@ class AtDataController extends StateNotifier<AsyncValue<List<AtData>>> {
     state = const AsyncValue.loading();
     final result = await ref.watch(dataRepositoryProvider).deleteData(atData);
     state = await AsyncValue.guard(() async => await ref.watch(dataRepositoryProvider).getData());
+
     return result;
   }
 
@@ -55,6 +56,7 @@ class FilterController extends StateNotifier<AsyncValue<List<AtData>>> {
 
   FilterController({required this.ref}) : super(const AsyncValue.loading()) {
     getData();
+    getFilteredAtData();
   }
 
   /// Get list of [AtData] associated with the current astign.
@@ -92,7 +94,7 @@ class FilterController extends StateNotifier<AsyncValue<List<AtData>>> {
   DateTime _getDate(DateTime dateTime) => DateTime(dateTime.year, dateTime.month, dateTime.day);
 
   /// Get the [AtData] associated with the current atsign that contains the input.
-  Future<void> getFilteredAtData() async {
+  void getFilteredAtData() {
     var searchFormModel = ref.watch(searchFormProvider);
 
     log(searchFormModel.searchRequest.toString());

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,6 +30,7 @@ Future<void> main() async {
   } catch (e) {
     _logger.finer('Environment failed to load from .env: ', e);
   }
+  AtSignLogger.root_level = 'finer';
   runApp(const ProviderScope(child: MyApp()));
 }
 

--- a/lib/screens/apps_screen.dart
+++ b/lib/screens/apps_screen.dart
@@ -34,7 +34,7 @@ class _DataStorageScreenState extends ConsumerState<AppsScreen> {
     // set the filter to apps
     ref.watch(searchFormProvider).filter[0] = Categories.apps;
     // filter atData by conditions set in searchFormProvider
-    await ref.watch(filterControllerProvider.notifier).getFilteredAtData();
+    ref.watch(filterControllerProvider.notifier).getFilteredAtData();
 
     if (context.mounted) {
       await Navigator.of(context).push(

--- a/lib/screens/browse_screen.dart
+++ b/lib/screens/browse_screen.dart
@@ -38,6 +38,14 @@ class _DataStorageScreenState extends ConsumerState<BrowseScreen> {
   ];
 
   @override
+  void initState() {
+    super.initState();
+    ref.read(filterControllerProvider.notifier).getData();
+    ref.read(searchFormProvider).searchRequest = [];
+    ref.read(searchFormProvider).filter = [];
+  }
+
+  @override
   Widget build(BuildContext context) {
     final state = ref.watch(filterControllerProvider);
     final searchRequest = ref.watch(searchFormProvider).searchRequest;

--- a/lib/screens/connected_atsigns_screen.dart
+++ b/lib/screens/connected_atsigns_screen.dart
@@ -36,7 +36,7 @@ class _DataStorageScreenState extends ConsumerState<ConnectedAtsignsScreen> {
     // set the filter to apps
     ref.watch(searchFormProvider).filter[0] = Categories.atsign;
     // filter atData by conditions set in searchFormProvider
-    await ref.watch(filterControllerProvider.notifier).getFilteredAtData();
+    ref.watch(filterControllerProvider.notifier).getFilteredAtData();
 
     if (context.mounted) {
       await Navigator.of(context).push(MaterialPageRoute(

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -26,8 +26,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   @override
   void initState() {
     WidgetsFlutterBinding.ensureInitialized().addPostFrameCallback((timeStamp) async {
-      await ref.watch(atDataControllerProvider.notifier).getData();
-      ref.watch(filterControllerProvider.notifier).getData();
+      await ref.read(atDataControllerProvider.notifier).getData();
     });
     super.initState();
   }
@@ -39,7 +38,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     // set the filter to apps
     ref.watch(searchFormProvider).filter[0] = Categories.keyTypes;
     // filter atData by conditions set in searchFormProvider
-    await ref.watch(filterControllerProvider.notifier).getFilteredAtData();
+    ref.watch(filterControllerProvider.notifier).getFilteredAtData();
 
     if (context.mounted) {
       await Navigator.of(context).push(

--- a/lib/widgets/at_data_expansion_panel_list.dart
+++ b/lib/widgets/at_data_expansion_panel_list.dart
@@ -267,7 +267,7 @@ class _AtDataExpansionPanelListState extends ConsumerState<AtDataExpansionPanelL
           isDeletable(widget.atData.atKey.toString())
               ? ElevatedButton(
                   onPressed: () async {
-                    await ref.watch(atDataControllerProvider.notifier).delete(widget.atData);
+                    await ref.read(atDataControllerProvider.notifier).delete(widget.atData);
                   },
                   style: ElevatedButton.styleFrom(
                     backgroundColor: Colors.red,

--- a/lib/widgets/at_data_list_widget.dart
+++ b/lib/widgets/at_data_list_widget.dart
@@ -1,11 +1,9 @@
-import 'dart:developer';
-
+import 'package:at_data_browser/utils/constants.dart';
 import 'package:at_data_browser/widgets/at_data_expansion_panel_list.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../domain.dart/at_data.dart';
-import '../utils/constants.dart';
 
 class AtDataListWidget extends StatefulWidget {
   const AtDataListWidget({
@@ -37,34 +35,39 @@ class _AtDataListWidgetState extends State<AtDataListWidget> {
             child: ListView.builder(
                 itemBuilder: (buildContext, builderIndex) {
                   isExpandPanel.add(false);
-                  return ExpansionPanelList(
-                    dividerColor: kDataStorageFadedColor,
-                    elevation: 0,
-                    expansionCallback: (int index, bool isExpanded) {
-                      log(isExpanded.toString());
-                      isExpandPanel[index] = !isExpanded;
-                      setState(() {
-                        log(isExpandPanel.toString());
-                      });
-                    },
+                  return Column(
                     children: [
-                      ExpansionPanel(
-                        canTapOnHeader: true,
-                        backgroundColor: Colors.transparent,
-                        headerBuilder: (BuildContext context, bool isExpanded) {
-                          isExpandPanel[0] = isExpanded;
+                      ExpansionPanelList.radio(
+                        elevation: 0,
+                        // expansionCallback: (int index, bool isExpanded) {
+                        //   log(isExpanded.toString());
+                        //   isExpandPanel[index] = !isExpanded;
+                        //   setState(() {
+                        //     log(isExpandPanel.toString());
+                        //   });
+                        // },
+                        children: [
+                          ExpansionPanelRadio(
+                            value: builderIndex,
+                            canTapOnHeader: true,
+                            backgroundColor: Colors.transparent,
+                            headerBuilder: (BuildContext context, bool isExpanded) {
+                              // isExpandPanel[0] = isExpanded;
 
-                          return Center(
-                            child: Padding(
-                              padding: const EdgeInsets.all(8.0),
-                              child: Text(widget.state.value![builderIndex].atKey.toString(),
-                                  style: Theme.of(context).textTheme.titleSmall),
-                            ),
-                          );
-                        },
-                        body: AtDataExpansionPanelList(atData: widget.state.value![builderIndex]),
-                        isExpanded: isExpandPanel[0],
-                      )
+                              return Center(
+                                child: Padding(
+                                  padding: const EdgeInsets.all(8.0),
+                                  child: Text(widget.state.value![builderIndex].atKey.toString(),
+                                      style: Theme.of(context).textTheme.titleSmall),
+                                ),
+                              );
+                            },
+                            body: AtDataExpansionPanelList(atData: widget.state.value![builderIndex]),
+                            // isExpanded: isExpandPanel[0],
+                          ),
+                        ],
+                      ),
+                      const Divider(color: kDataStorageFadedColor, thickness: 1)
                     ],
                   );
                 },

--- a/lib/widgets/search_widget.dart
+++ b/lib/widgets/search_widget.dart
@@ -23,15 +23,13 @@ class _SearchWidgetState extends ConsumerState<SearchWidget> {
         await ref.read(appsController.notifier).getFilteredConnectedApps(value);
         break;
       case SearchWidgetFilter.atSigns:
-        await ref
-            .read(connectedAtsignsControllerProvider.notifier)
-            .getFilteredConnectedAtsign(value);
+        await ref.read(connectedAtsignsControllerProvider.notifier).getFilteredConnectedAtsign(value);
         break;
     }
   }
 
   Future<void> _onPressed() async {
-    await ref.watch(filterControllerProvider.notifier).getFilteredAtData();
+    ref.watch(filterControllerProvider.notifier).getFilteredAtData();
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 
 dependencies:
   at_app_flutter: ^5.0.1
-  at_client_mobile: ^3.2.6
+  at_client_mobile: ^3.2.9
   at_common_flutter: ^2.0.11
   at_contact: 3.0.6
   at_contacts_flutter: ^4.0.9


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
close #23 and closes #4 by maintaining the filter state of the data storage screen after an atKey is deleted.
**- How I did it**
Call the filter function after the atKey is deleted
**- How to verify it**
Navigate to Data Storage screen
Add a filter condition
Delete an atKey
Filter state  should remain the same less the deleted atKey.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Filter state of the Data Storage Screen now remains the same after an atKey is deleted, less the deleted key.