### PR TITLE
fix: const removed from a widget

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -66,12 +66,12 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           Container(
             margin: const EdgeInsets.only(right: 16.0),
             child: IconButton(
-            icon: const Icon(Icons.settings_outlined),
-            color: Colors.black,
-            iconSize: 40,
-            onPressed: () {
-              Navigator.of(context).pushNamed(SettingsScreen.route);
-            },
+              icon: const Icon(Icons.settings_outlined),
+              color: Colors.black,
+              iconSize: 40,
+              onPressed: () {
+                Navigator.of(context).pushNamed(SettingsScreen.route);
+              },
             ),
           ),
         ],
@@ -82,22 +82,25 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
             Expanded(
               child: Column(children: [
                 ListTile(
-                      title: const Padding(
-                        padding: EdgeInsets.only(left: 25.0),
-                        child: Row(
-                          children: [
-                            Text(
-                              'Data',
-                              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 30),
-                            ),
-                            Text('Browser', style: TextStyle(fontSize: 30), ),
-                          ],
+                  title: Padding(
+                    padding: const EdgeInsets.only(left: 25.0),
+                    child: Row(
+                      children: const [
+                        Text(
+                          'Data',
+                          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 30),
                         ),
-                      ),
-                      subtitle: Padding(
-                        padding: const EdgeInsets.only(left: 25.0),
-                        child: Text(atsign ?? ''),
-                      ),
+                        Text(
+                          'Browser',
+                          style: TextStyle(fontSize: 30),
+                        ),
+                      ],
+                    ),
+                  ),
+                  subtitle: Padding(
+                    padding: const EdgeInsets.only(left: 25.0),
+                    child: Text(atsign ?? ''),
+                  ),
                 ),
                 gapH64,
                 NotificationListTile.notify(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -553,10 +553,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "910f85bce16fb5c6f614e117efa303e85a1731bb0081edf3604a2ae6e9a3cc91"
+      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.17.0"
+    version: "0.18.1"
   io:
     dependency: transitive
     description:
@@ -702,7 +702,7 @@ packages:
     source: hosted
     version: "1.0.6"
   package_info_plus_windows:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: package_info_plus_windows
       sha256: "79524f11c42dd9078b96d797b3cf79c0a2883a50c4920dc43da8562c115089bc"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Removed const constructor from a padding widget in the Home Screen
**- How I did it**

**- How to verify it**
Run the flutter app
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
--> 
const removed from a widget